### PR TITLE
#963: Extend generator with adding debug log of exception whe…

### DIFF
--- a/Addons/Entitas.VisualDebugging.CodeGeneration.Plugins/Entitas.VisualDebugging.CodeGeneration.Plugins/ContextObserverGenerator.cs
+++ b/Addons/Entitas.VisualDebugging.CodeGeneration.Plugins/Entitas.VisualDebugging.CodeGeneration.Plugins/ContextObserverGenerator.cs
@@ -20,7 +20,8 @@ namespace Entitas.VisualDebugging.CodeGeneration.Plugins {
     public void InitializeContextObservers() {
         try {
 ${contextObservers}
-        } catch(System.Exception) {
+        } catch(System.Exception e) {
+            UnityEngine.Debug.LogError(e);
         }
     }
 


### PR DESCRIPTION
#963 
I think that I had got same error when developing my examples and got empty hierarchy. My investigation carried out to the fact that registering of context observers has error and crashing flow without any exception. 

This will help other devs to catch and understand issue much more faster

Error was in trying to declarate context as field of MonoBehaviour class

